### PR TITLE
Respond to "patch #1234" as well as "patch 1234"

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -42,7 +42,7 @@ import requests
 Tool to generate gerrit review URLs
 '''
 
-patch_re = r'.*?(?:patch\s+){1}(\d+).*?'
+patch_re = r'.*?(?:patch\s+){1}#?(\d+).*?'
 patch_regex = re.compile(patch_re)
 
 REVIEW_SERVER = 'https://review.openstack.org'


### PR DESCRIPTION
Noticed in my scrollback this morning:

```
    clayg   wbhuber: lp bug #1452431 and patch #241571
openstack   Launchpad bug 1452431 in OpenStack Object Storage (swift) "some parts replicas assigned to duplicate devices in the ring" [High,Confirmed] https://launchpad.net/bugs/1452431 - Assigned to Samuel Merritt (torgomatic)
```

...but nothing from patchbot :cry:
